### PR TITLE
Update formhame

### DIFF
--- a/COMMANDS/formhame
+++ b/COMMANDS/formhame
@@ -89,6 +89,10 @@ def getInputBlock(line,html_file):
 		i = line.index(">")
 		return line[0:i+1],line[i+1:]
 
+	if ">" in line:
+		i = line.index(">")
+		return line[0:i+1],line[i+1:]
+
 	lines = [ line ]
 	for line in html_file:
 		if line[-2:] == "/>":


### PR DESCRIPTION
I know the rule of this command. That is all "`<input>`" tags in the HTML that formhame receives must be terminated with "`/>`" as in "`<input name="PARAM" value="1" />`." However, I think it is a problem to exit itself unintentionally when such bad <input> tags come. So I revised this code to solve the problem.

formhameに与えるHTMLの`<input>`タグは`<input />`のように単独閉じ形式にしなければならないという決まりがあるものの、だからといって閉じてない`<input>`タグを与えるとコマンドが強制終了してしまうのは問題であると思ったために、その問題点を修正した。